### PR TITLE
Update Image.h

### DIFF
--- a/src/Image.h
+++ b/src/Image.h
@@ -4,7 +4,7 @@ struct Image
 {
     void Initialize();
 
-    static std::tuple<uint32_t, uint16_t> GetSupportedVersion() noexcept { return std::make_tuple(1, 61); }
+    static std::tuple<uint32_t, uint16_t> GetSupportedVersion() noexcept { return std::make_tuple(1, 62); }
 
     static uint64_t MakeVersion(const uint32_t acMajor, const uint16_t acMinor) noexcept { return static_cast<uint64_t>(acMajor) << 32 | static_cast<uint64_t>(acMinor) << 16; }
 


### PR DESCRIPTION
Mits found:
[2023-04-12 01:49:19 UTC+02:00] [error] [Options] [5284] Unsupported game version! Only 1.61 is supported.

I assume this is what's missing